### PR TITLE
Fix missing 'link_type' variable in view() for Link with Type Selection

### DIFF
--- a/generator_templates/_functions/prepare_for_view_external_link.txt
+++ b/generator_templates/_functions/prepare_for_view_external_link.txt
@@ -37,6 +37,7 @@
                 $link = BASE_URL.$separator.$link;
             }
             $this->set($linkFieldName.'_link', $link);
+            $this->set($linkFieldName.'_link_type', 'external_link');
 
         } elseif ($type == 'entry') {
 
@@ -61,7 +62,8 @@
                 }
                 $link = BASE_URL.$separator.$link;
             }
-            $entry[$linkFieldName.'_link'] = $link;
+            $entry[$linkFieldName.'_link']      = $link;
+            $entry[$linkFieldName.'_link_type'] = 'external_link';
 
             return $entry;
 

--- a/generator_templates/_functions/prepare_for_view_link_from_file_manager.txt
+++ b/generator_templates/_functions/prepare_for_view_link_from_file_manager.txt
@@ -52,6 +52,7 @@
             $this->set($fileIDFieldName.'_object', $fileObject);
             $this->set($fileIDFieldName.'_filename', $filename);
             $this->set($fileIDFieldName.'_link', $link);
+            $this->set($fileIDFieldName.'_link_type', 'link_from_file_manager');
 
         } elseif ($type == 'entry') {
 
@@ -65,9 +66,10 @@
             $entry[$newWindowFieldName] = $newWindow;
 
             // Additional data
-            // $entry[$fileIDFieldName.'_object']   = $fileObject;
-            $entry[$fileIDFieldName.'_filename'] = $filename;
-            $entry[$fileIDFieldName.'_link']     = $link;
+            // $entry[$fileIDFieldName.'_object']    = $fileObject;
+            $entry[$fileIDFieldName.'_filename']  = $filename;
+            $entry[$fileIDFieldName.'_link']      = $link;
+            $entry[$fileIDFieldName.'_link_type'] = 'link_from_file_manager';
 
             return $entry;
 

--- a/generator_templates/_functions/prepare_for_view_link_from_sitemap.txt
+++ b/generator_templates/_functions/prepare_for_view_link_from_sitemap.txt
@@ -50,6 +50,7 @@
             $this->set($pageIDFieldName.'_object', $pageObject);
             $this->set($pageIDFieldName.'_name', $name);
             $this->set($pageIDFieldName.'_link', $link);
+            $this->set($pageIDFieldName.'_link_type', 'link_from_sitemap');
 
         } elseif ($type == 'entry') {
 
@@ -63,9 +64,10 @@
             $entry[$newWindowFieldName] = $newWindow;
 
             // Additional data
-            // $entry[$pageIDFieldName.'_object'] = $pageObject;
-            $entry[$pageIDFieldName.'_name']   = $name;
-            $entry[$pageIDFieldName.'_link']   = $link;
+            // $entry[$pageIDFieldName.'_object']    = $pageObject;
+            $entry[$pageIDFieldName.'_name']      = $name;
+            $entry[$pageIDFieldName.'_link']      = $link;
+            $entry[$pageIDFieldName.'_link_type'] = 'link_from_sitemap';
 
             return $entry;
 


### PR DESCRIPTION
Example usage in view():
a) Basic: $exampleHandle_link_type
b) Entries: $entry['exampleHandle_link_type']

It will return one of 3 possible types:
a) link_from_file_manager
b) link_from_sitemap
c) external_link